### PR TITLE
Add support for Ubuntu 14.04 (Trusty)

### DIFF
--- a/examples/Vagrantfile
+++ b/examples/Vagrantfile
@@ -15,7 +15,7 @@ if [ "up", "provision" ].include?(ARGV.first) &&
 end
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "ubuntu/precise64"
+  config.vm.box = "ubuntu/trusty64"
 
   config.vm.provision "ansible" do |ansible|
     ansible.playbook = "site.yml"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -8,8 +8,9 @@ galaxy_info:
   platforms:
   - name: Ubuntu
     versions:
+    - trusty
     - precise
   categories:
   - system
 dependencies:
-  - { role: "azavea.java", java_version: "7u71-2.5.3-0ubuntu0.12.04.1" }
+  - { role: "azavea.java", java_version: "7u71-2.5.3-0ubuntu0.14.04.1" }


### PR DESCRIPTION
This changeset simply adds support for Trusty by making it the default case.
