### PR TITLE
Update main.yml

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Configure Mesosphere APT key
-  apt_key: keyserver=keyserver.ubuntu.com
+  apt_key: keyserver=hkp://keyserver.ubuntu.com:80
            id=E56151BF
            state=present
 


### PR DESCRIPTION
Specifying port 80 helps with many proxy servers, and keyserver.ubuntu.com supports it for HKP.
